### PR TITLE
Improve Servant response.

### DIFF
--- a/Backend/Models/Servant.cs
+++ b/Backend/Models/Servant.cs
@@ -6,7 +6,7 @@ namespace ZetsubouGacha.Models
     public class Servant
     {
         [BsonId]
-        public ObjectId ObjectId { get; set; }
+        ObjectId _id { get; }
 
         [BsonElement("id")]
         public int Id { get; set; }


### PR DESCRIPTION
The previous Servant response returned the MongoDB internal details contained in ObjectId.
By limiting scope, the response is much more appropriate.